### PR TITLE
Fix corner case with checking boundaries

### DIFF
--- a/megahal.py
+++ b/megahal.py
@@ -165,7 +165,7 @@ class Brain(object):
             def boundary(string, position):
                 if position == 0:
                     boundary = False
-                elif position == len(string):
+                elif position == len(string)+1:
                     boundary = True
                 elif (string[position] == "'" and
                     string[position - 1].isalpha() and


### PR DESCRIPTION
Strings that end in `'` can get an IndexError because the check for being at the end of the string does not take into account the zero indexing. Fix #1.
